### PR TITLE
Added cached_write functionality

### DIFF
--- a/_modules/vault.py
+++ b/_modules/vault.py
@@ -157,7 +157,7 @@ def clean_expired_leases(prefix='', time_horizon=0):
     return expired_leases
 
 
-def check_cached_lease(path, cache_prefix='', **kwargs):
+def check_cached_lease(path, cache_prefix='', renew_lease=True, **kwargs):
     """Check whether cached leases have expired and if they are renewable.
 
     :param path: path to the full vault cache path
@@ -185,7 +185,7 @@ def check_cached_lease(path, cache_prefix='', **kwargs):
             lease_valid = True
         else:
             lease_valid = False
-            if not vault_data['renewable']:
+            if not vault_data['renewable'] or not renew_lease:
                 vault_client.delete(cache_path)
             else:
                 __salt__['event.send'](
@@ -218,6 +218,7 @@ def cached_read(path, cache_prefix='', **kwargs):
     """
     cache_path, vault_client, vault_data = check_cached_lease(path,
                                                               cache_prefix='',
+                                                              renew_lease=True,
                                                               **kwargs)
     if not vault_data:
         vault_data = vault_client.read(path)
@@ -240,6 +241,7 @@ def cached_write(path, cache_prefix='', **kwargs):
     """
     cache_path, vault_client, vault_data = check_cached_lease(path,
                                                               cache_prefix='',
+                                                              renew_lease=True,
                                                               **kwargs)
     if not vault_data:
         vault_data = vault_client.write(path, **kwargs)

--- a/_modules/vault.py
+++ b/_modules/vault.py
@@ -225,10 +225,10 @@ def cached_write(path, cache_prefix='', **kwargs):
                 'expired. It will be regenerated and cached with new data.'
                 .format(cache_path)
             })
-        vault_data = vault_client.read(path)
+        vault_data = vault_client.write(path, **kwargs)
         vault_data['created'] = datetime.utcnow().isoformat()
         vault_client.write(cache_path, value=vault_data)
-        vault_data = vault_client.write(cache_path)['data']['value']
+        vault_data = vault_client.read(cache_path)['data']['value']
 
     return vault_data
 

--- a/_modules/vault.py
+++ b/_modules/vault.py
@@ -158,6 +158,14 @@ def clean_expired_leases(prefix='', time_horizon=0):
 
 
 def check_cached_lease(path, cache_prefix='', **kwargs):
+    """Check whether cached leases have expired and if they are renewable.
+
+    :param path: path to the full vault cache path
+    :param cache_prefix: usually the minion_id
+    :param **kwargs: other data that the function might require
+    :rtype: list, dict
+
+    """
     cache_base_path = __opts__.get('vault.cache_base_path',
                                    'secret/pillar_cache')
     cache_path = '/'.join((cache_base_path, cache_prefix, path))
@@ -178,32 +186,39 @@ def check_cached_lease(path, cache_prefix='', **kwargs):
         else:
             lease_valid = False
             if not vault_data['renewable']:
-                lease_renwable = False
                 vault_client.delete(cache_path)
             else:
                 __salt__['event.send'](
                     'vault/cache/renew/{0}'.format(cache_path),
-                    data={
-                        'message': 'The cached lease at {0} is renewable. It will be '
-                        'renewed and cached data will remain intact.'
-                        .format(cache_path)
-                    })
-                lease_renwable = True
+                    data={'message': 'The cached lease at {0} is renewable. '
+                                     'It will be renewed and cached data '
+                                     'will remain intact.'
+                                     .format(cache_path)})
                 vault_client.renew_secret(vault_data['lease_id'])
 
     if not vault_data or not (lease_valid and not vault_data['renewable']):
         __salt__['event.send'](
             'vault/cache/miss/{0}'.format(cache_path),
-            data={
-                'message': 'The cached lease at {0} is either invalid or '
-                'expired. It will be regenerated and cached with new data.'
-                .format(cache_path)
-            })
+            data={'message': 'The cached lease at {0} is either invalid or '
+                             'expired and not renewable. It will be '
+                             'regenerated and cached with new data.'
+                             .format(cache_path)})
     return cache_path, vault_client, vault_data
 
 
 def cached_read(path, cache_prefix='', **kwargs):
-    cache_path, vault_client, vault_data = check_cached_lease(path, cache_prefix='', **kwargs)
+    """Generate new secret through vault read function and copy it to the vault
+    cache path.
+
+    :param path: path to the full vault cache path
+    :param cache_prefix: usually the minion_id
+    :param **kwargs: other data that the function might require
+    :rtype: list, dict
+
+    """
+    cache_path, vault_client, vault_data = check_cached_lease(path,
+                                                              cache_prefix='',
+                                                              **kwargs)
     if not vault_data:
         vault_data = vault_client.read(path)
         vault_data['created'] = datetime.utcnow().isoformat()
@@ -214,7 +229,18 @@ def cached_read(path, cache_prefix='', **kwargs):
 
 
 def cached_write(path, cache_prefix='', **kwargs):
-    cache_path, vault_client, vault_data = check_cached_lease(path, cache_prefix='', **kwargs)
+    """Generate new secret through vault write function and copy it to the vault
+    cache path.
+
+    :param path: path to the full vault cache path
+    :param cache_prefix: usually the minion_id
+    :param **kwargs: other data that the function might require
+    :rtype: list, dict
+
+    """
+    cache_path, vault_client, vault_data = check_cached_lease(path,
+                                                              cache_prefix='',
+                                                              **kwargs)
     if not vault_data:
         vault_data = vault_client.write(path, **kwargs)
         vault_data['created'] = datetime.utcnow().isoformat()
@@ -227,8 +253,8 @@ def cached_write(path, cache_prefix='', **kwargs):
 def list_cache_paths(prefix=None, cache_filter=''):
     client = __utils__['vault.build_client']()
     if not prefix:
-       prefix = __opts__.get('vault.cache_base_path',
-                             'secret/pillar_cache')
+        prefix = __opts__.get('vault.cache_base_path',
+                              'secret/pillar_cache')
 
     caches = client.list(
         prefix
@@ -257,6 +283,7 @@ def list_cached_data(prefix=None, cache_filter='', attribute_path=''):
                                                          attribute_path)
         cached_data.append((path, cache_data))
     return cached_data
+
 
 def purge_cache_data(cache_filter):
     """Scan cached leases and delete any that match the given prefix

--- a/_utils/vault.py
+++ b/_utils/vault.py
@@ -304,7 +304,7 @@ class VaultClient(object):
         except InvalidPath:
             return None
 
-    def write(self, path, translate_newlines=False, wrap_ttl=None, **kwargs):
+    def update(self, path, translate_newlines=False, wrap_ttl=None, **kwargs):
         """
         PUT /<path>
         """
@@ -314,6 +314,21 @@ class VaultClient(object):
                     kwargs[k] = v.replace(r'\n', '\n')
 
         response = self._put(
+            '/v1/{0}'.format(path), json=kwargs, wrap_ttl=wrap_ttl)
+
+        if response.status_code == 200:
+            return response.json()
+
+    def write(self, path, translate_newlines=False, wrap_ttl=None, **kwargs):
+        """
+        POST /<path>
+        """
+        if translate_newlines:
+            for k, v in kwargs.items():
+                if isinstance(v, six.string_types):
+                    kwargs[k] = v.replace(r'\n', '\n')
+
+        response = self._post(
             '/v1/{0}'.format(path), json=kwargs, wrap_ttl=wrap_ttl)
 
         if response.status_code == 200:


### PR DESCRIPTION
To use vault pki functionality and avoid generating certs when pillar is rendered, we need a way to cache certs and only generate new ones when current ones are about to expire. This is different than the other creds since this requires a `POST` request as opposed to a `GET` request to generate the cert and thus we decided to add a `cached_write` function to handle that request.