### PR TITLE
Changes to add lease renewal option

### DIFF
--- a/_modules/vault.py
+++ b/_modules/vault.py
@@ -171,7 +171,7 @@ def check_cached_lease(path, cache_prefix='', renew_lease=True, **kwargs):
                                    'secret/pillar_cache')
     cache_path = '/'.join((cache_base_path, cache_prefix, path))
     renewal_threshold = __opts__.get('vault.lease_renewal_threshold',
-                                     {'days': 7})
+                                    {'days': 7})
     vault_client = __utils__['vault.build_client']()
 
     vault_data = vault_client.read(cache_path)
@@ -185,14 +185,14 @@ def check_cached_lease(path, cache_prefix='', renew_lease=True, **kwargs):
             lease_valid = True
         # Lease might sitll be in cache even though it has expired.
         # This verifies that the lease is still valid and can be renewed.
-        elif lease and vault_data['lease_duration'] > 0:
-            if vault_data['renewable']:
-                log.info('Renewing lease')
-                # Setting increment to zero will renew the lease to its specified ttl
-                vault_client.renew_secret(lease['data']['id'], increment=0)
+        elif lease and lease['data']['renewable']:
+            log.info('Renewing lease')
+            # Setting increment to zero will renew the lease to its specified ttl
+            vault_client.renew_secret(lease['data']['id'], increment=0)
         else:
             lease_valid = False
-            vault_data = vault_client.delete(cache_path)
+            vault_client.delete(cache_path)
+            vault_data = None
 
     if not vault_data or not lease_valid:
         __salt__['event.send'](

--- a/_utils/vault.py
+++ b/_utils/vault.py
@@ -501,7 +501,7 @@ class VaultClient(object):
         try:
             lease = self.write('sys/leases/lookup', lease_id=lease_id)
         except InvalidRequest:
-            log.exception('The specified lease is not valid')
+            log.warning('The following lease_id is not valid: %s', lease_id)
             lease = None
 
         return lease


### PR DESCRIPTION
Did the following:
- Added `renew_lease` option to cached_read and cached_write methods. The one caveat to keep in mind is that lease renewal can never exceed value of `max_ttl`. In my testing, I configured `max_ttl=0` and `ttl=300` and was able to continually renew the lease prior to it expiring by increments of ttl.
- Tweaked some conditions based on results from testing.